### PR TITLE
Add link to fractional seconds support in MySQL 5.6.4+

### DIFF
--- a/mysql-async/README.md
+++ b/mysql-async/README.md
@@ -16,7 +16,7 @@ You can find more information about the MySQL network protocol [here](http://dev
 ## Gotchas
 
 * `unsigned` types are not supported, their behaviour when using this driver is undefined.
-* MySQL truncates millis in `datetime`, `timestamp` and `time` fields. If your date has millis,
+* Prior to version [5.6.4](http://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html) MySQL truncates millis in `datetime`, `timestamp` and `time` fields. If your date has millis,
   they will be gone ([docs here](http://dev.mysql.com/doc/refman/5.0/en/fractional-seconds.html))
 * Timezone support is rather complicated ([see here](http://dev.mysql.com/doc/refman/5.5/en/time-zone-support.html)),
   avoid using timezones in MySQL. This driver just stores the dates as they are and won't perform any computation


### PR DESCRIPTION
I haven't tried this driver yet, but it looks really good.

Noticed the docs talk about the millisecond stripping behaviour of MySQL and thought it was worth mentioning that this is now fixed in 5.6.4+.
