### PR TITLE
Add support for Options (Some/None) in prepared stmt parameters

### DIFF
--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/PreparedStatementsSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/PreparedStatementsSpec.scala
@@ -323,6 +323,29 @@ class PreparedStatementsSpec extends Specification with ConnectionHelper {
       }
     }
 
+    "support setting None to a column" in {
+      withConnection {
+        connection =>
+          executeQuery(connection, "CREATE TEMPORARY TABLE timestamps ( id INT NOT NULL, moment TIMESTAMP NULL, primary key (id))")
+          executePreparedStatement(connection, "INSERT INTO timestamps (moment, id) VALUES (?, ?)", None, 10)
+          val row = executePreparedStatement(connection, "SELECT moment, id FROM timestamps").rows.get(0)
+          row("id") === 10
+          row("moment") === null
+      }
+    }
+
+    "support setting Some(value) to a column" in {
+      withConnection {
+        connection =>
+          executeQuery(connection, "CREATE TEMPORARY TABLE timestamps ( id INT NOT NULL, moment TIMESTAMP NULL, primary key (id))")
+          val moment = LocalDateTime.now().withMillisOfDay(0) // cut off millis to match timestamp
+          executePreparedStatement(connection, "INSERT INTO timestamps (moment, id) VALUES (?, ?)", Some(moment), 10)
+          val row = executePreparedStatement(connection, "SELECT moment, id FROM timestamps").rows.get(0)
+          row("id") === 10
+          row("moment") === moment
+      }
+    }
+
   }
 
 }

--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/binary/BinaryRowEncoderSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/binary/BinaryRowEncoderSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.mauricio.async.db.mysql.binary
+
+import org.jboss.netty.util.CharsetUtil
+import org.specs2.mutable.Specification
+
+class BinaryRowEncoderSpec extends Specification {
+
+  val encoder = new BinaryRowEncoder(CharsetUtil.UTF_8)
+
+  "binary row encoder" should {
+
+    "encode Some(value) like value" in {
+      val actual = encoder.encode(List(Some(1l), Some("foo")))
+      val expected = encoder.encode(List(1l, "foo"))
+
+      actual mustEqual expected
+
+    }
+
+    "encode None as null" in {
+      val actual = encoder.encode(List(None))
+      val expected = encoder.encode(List(null))
+
+      actual mustEqual expected
+    }
+
+  }
+
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/PreparedStatementEncoderHelper.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/PreparedStatementEncoderHelper.scala
@@ -53,7 +53,7 @@ trait PreparedStatementEncoderHelper {
     bindBuffer.writeShort(values.length)
 
     for (value <- values) {
-      if (value == null) {
+      if (value == null || value == None) {
         bindBuffer.writeInt(-1)
       } else {
         val content = encoder.encode(value).getBytes(charset)

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PostgreSQLColumnEncoderRegistrySpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PostgreSQLColumnEncoderRegistrySpec.scala
@@ -1,0 +1,51 @@
+package com.github.mauricio.async.db.postgresql
+
+import com.github.mauricio.async.db.postgresql.column.PostgreSQLColumnEncoderRegistry
+import org.specs2.mutable.Specification
+
+class PostgreSQLColumnEncoderRegistrySpec extends Specification {
+
+  val encoder = new PostgreSQLColumnEncoderRegistry
+
+  "column encoder registry" should {
+
+    "encode Some(value) like value" in {
+      
+      val actual = encoder.encode(Some(1l))
+      val expected = encoder.encode(1l)
+
+      actual mustEqual expected
+    }
+
+    "encode Some(value) in list like value in list" in {
+      
+      val actual = encoder.encode(List(Some(1l), Some("foo")))
+      val expected = encoder.encode(List(1l, "foo"))
+
+      actual mustEqual expected
+    }
+
+    "encode None as null" in {
+      val actual = encoder.encode(None)
+      val expected = encoder.encode(null)
+
+      actual mustEqual expected
+    }
+
+    "determine kindOf Some(value) like kindOf value" in {
+      val actual = encoder.kindOf(Some(1l))
+      val expected = encoder.kindOf(1l)
+
+      actual mustEqual expected
+    }
+
+    "determine kindOf None like kindOf null" in {
+      val actual = encoder.kindOf(None)
+      val expected = encoder.kindOf(null)
+
+      actual mustEqual expected
+    }
+
+  }
+
+}


### PR DESCRIPTION
Allows to specify Some(value) or None in prepared stmt parameters,
as until now an Option had to be passed as `opt.getOrElse(null)`.

Is implemented for mysql and postgresql.

Closes #30
