### PR TITLE
Support 'postgres' protocol in heroku like db urls.

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
@@ -20,7 +20,7 @@ object ParserURL {
   def parse(connectionURL: String): Map[String, String] = {
     val properties: Map[String, String] = Map()
     val pgurl1 = """(jdbc:postgresql)://(.*):(\d+)/(.*)\?username=(.*)&password=(.*)""".r
-    val pgurl2 = """(postgresql)://(.*):(.*)@(.*):(\d+)/(.*)""".r
+    val pgurl2 = """(postgres|postgresql)://(.*):(.*)@(.*):(\d+)/(.*)""".r
 
     if (connectionURL.startsWith("jdbc")) {
       connectionURL match {
@@ -31,7 +31,7 @@ object ParserURL {
 
     } else {
 
-      if (connectionURL.startsWith("postgresql")) {
+      if (connectionURL.startsWith("postgres")) {
         connectionURL match {
           case pgurl2(protocol, username, password, server, port, dbname) => {
             properties + (PGHOST -> unwrapIpv6address(server)) + (PGPORT -> port) + (PGDBNAME -> dbname) + (PGUSERNAME -> username) + (PGPASSWORD -> password)

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/util/URLParserSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/util/URLParserSpec.scala
@@ -33,8 +33,19 @@ class URLParserSpec extends Specification {
       configuration.port === 9987
     }
 
-    "create a connection from a heroku like URL" in {
+    "create a connection from a heroku like URL using 'postgresql' protocol" in {
       val connectionUri = "postgresql://john:doe@128.567.54.90:9987/my_database"
+
+      val configuration = URLParser.parse(connectionUri)
+      configuration.username === "john"
+      configuration.password === Some("doe")
+      configuration.database === Some("my_database")
+      configuration.host === "128.567.54.90"
+      configuration.port === 9987
+    }
+
+    "create a connection from a heroku like URL using 'postgres' protocol" in {
+      val connectionUri = "postgres://john:doe@128.567.54.90:9987/my_database"
 
       val configuration = URLParser.parse(connectionUri)
       configuration.username === "john"


### PR DESCRIPTION
Heroku like db urls were supported with 'postgresql' protocol.
In my heroku app, the `$DATABASE_URL` was set with 'postgres' protocol,
so that the db url could not be parsed:

```
2013-07-01T11:51:41.448436+00:00 app[web.1]: [info] application - $DATABASE_URL: postgres://xyz:xyz@ec2-xx-xx-xx-xx.compute-1.amazonaws.com:5432/somedb
2013-07-01T11:51:41.521684+00:00 app[web.1]: java.util.NoSuchElementException: key not found: host
2013-07-01T11:51:41.517811+00:00 app[web.1]: Oops, cannot start the server.
2013-07-01T11:51:41.522280+00:00 app[web.1]:    at scala.collection.MapLike$class.apply(MapLike.scala:141)
2013-07-01T11:51:41.522379+00:00 app[web.1]:    at scala.collection.AbstractMap.apply(Map.scala:58)
2013-07-01T11:51:41.523042+00:00 app[web.1]:    at play.api.Play$$anonfun$start$1.apply$mcV$sp(Play.scala:63)
2013-07-01T11:51:41.522541+00:00 app[web.1]:    at Global$.getDbConfig(Global.scala:42)
2013-07-01T11:51:41.522458+00:00 app[web.1]:    at com.github.mauricio.async.db.postgresql.util.URLParser$.parse(URLParser.scala:45)
```

This change supports both 'postgresql' and 'postgres' protocols.
