### PR TITLE
Fixing spec to reproduce issue #39 (the cause is date type column)

### DIFF
--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/PreparedStatementsSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/PreparedStatementsSpec.scala
@@ -348,7 +348,8 @@ class PreparedStatementsSpec extends Specification with ConnectionHelper {
 
       val create = """CREATE TEMPORARY TABLE posts (
                      |       id INT NOT NULL AUTO_INCREMENT,
-                     |       some_text TEXT not null,
+                     |       some_text TEXT NOT NULL,
+                     |       some_date DATE,
                      |       primary key (id) )""".stripMargin
 
       val insert = "insert into posts (some_text) values (?)"


### PR DESCRIPTION
I found that DATE type is the cause.

https://github.com/mauricio/postgresql-async/issues/39

mysql-async throws IllegalArgumentException when limit size is larger than the size of existing records
