### PR TITLE
Add AsyncObjectPool.use to combine take and giveBack

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/AsyncObjectPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/AsyncObjectPool.scala
@@ -62,4 +62,19 @@ trait AsyncObjectPool[T] {
 
   def close : Future[AsyncObjectPool[T]]
 
+  /**
+   *
+   * Retrieve and use an object from the pool for a single computation, returning it when the operation completes.
+   *
+   * @param f function that uses the object
+   * @return f wrapped with take and giveBack
+   */
+
+  def use[A](f : T => Future[A])(implicit executionContext : scala.concurrent.ExecutionContext) : Future[A] =
+    take.flatMap { item =>
+      f(item).andThen { case _ =>
+        giveBack(item)
+      }
+    }
+
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
@@ -78,14 +78,8 @@ class ConnectionPool[T <: Connection](
    * @return
    */
 
-  def sendQuery(query: String): Future[QueryResult] = {
-    this.take.flatMap( {
-      connection =>
-        connection.sendQuery(query).andThen( {
-          case c => this.giveBack(connection)
-        })(executionContext)
-    })(executionContext)
-  }
+  def sendQuery(query: String): Future[QueryResult] =
+    this.use(_.sendQuery(query))(executionContext)
 
   /**
    *
@@ -98,13 +92,7 @@ class ConnectionPool[T <: Connection](
    * @return
    */
 
-  def sendPreparedStatement(query: String, values: Seq[Any] = List()): Future[QueryResult] = {
-    this.take.flatMap( {
-      connection =>
-        connection.sendPreparedStatement(query, values).andThen( {
-          case c => this.giveBack(connection)
-        })(executionContext)
-    })(executionContext)
-  }
+  def sendPreparedStatement(query: String, values: Seq[Any] = List()): Future[QueryResult] =
+    this.use(_.sendPreparedStatement(query, values))(executionContext)
 
 }


### PR DESCRIPTION
This seems like a common use case, and as long as the provided function doesn't hold onto the provided item it should be safe.  Is this reasonable?  Is it sufficiently non-trivial for addition?  It eliminates duplicate code in ConnectionPool.

I'm working up to writing a withTransaction-like function but want to make sure I'm on the right track.
