### PR TITLE
Add support for postgres inet type as InetAddress

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/column/InetEncoderDecoder.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/column/InetEncoderDecoder.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ * Copyright 2013 Dylan Simon
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.mauricio.async.db.column
+
+import java.net.InetAddress
+import com.github.mauricio.async.db.exceptions.DateEncoderNotAvailableException
+
+object InetEncoderDecoder extends ColumnEncoderDecoder {
+
+  override def encode(value : Any) : String = value match {
+    case i : InetAddress => i.getHostAddress
+    case s : String => s 
+    case _ => throw new DateEncoderNotAvailableException(value)
+  }
+
+  def decode(value : String) : InetAddress =
+    /* this is correct if value is a syntactially valid IP, otherwise it will do an inappropriate DNS lookup */
+    InetAddress.getByName(value)
+
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
@@ -55,6 +55,8 @@ object ColumnTypes {
   final val IntervalArray = 1187
   final val Boolean = 16
   final val BooleanArray = 1000
+  final val Inet = 869
+  final val InetArray = 1041
 
   final val ByteA = 17
   final val ByteA_Array = 1001

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnDecoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnDecoderRegistry.scala
@@ -45,6 +45,7 @@ class PostgreSQLColumnDecoderRegistry( charset : Charset = CharsetUtil.UTF_8 ) e
   private final val timeArrayDecoder = new ArrayDecoder(TimeEncoderDecoder.Instance)
   private final val timeWithTimestampArrayDecoder = new ArrayDecoder(TimeWithTimezoneEncoderDecoder)
   private final val intervalArrayDecoder = new ArrayDecoder(PostgreSQLIntervalEncoderDecoder)
+  private final val inetArrayDecoder = new ArrayDecoder(InetEncoderDecoder)
 
   override def decode(kind: ColumnData, value: ByteBuf, charset: Charset): Any = {
     decoderFor(kind.dataType).decode(kind, value, charset)
@@ -102,6 +103,9 @@ class PostgreSQLColumnDecoderRegistry( charset : Charset = CharsetUtil.UTF_8 ) e
 
       case Interval => PostgreSQLIntervalEncoderDecoder
       case IntervalArray => this.intervalArrayDecoder
+
+      case Inet => InetEncoderDecoder
+      case InetArray => this.inetArrayDecoder
 
       case OIDArray => this.stringArrayDecoder
       case MoneyArray => this.stringArrayDecoder

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
@@ -58,6 +58,8 @@ class PostgreSQLColumnEncoderRegistry extends ColumnEncoderRegistry {
     classOf[ReadablePeriod] -> (PostgreSQLIntervalEncoderDecoder -> ColumnTypes.Interval),
     classOf[ReadableDuration] -> (PostgreSQLIntervalEncoderDecoder -> ColumnTypes.Interval),
 
+    classOf[java.net.InetAddress] -> (InetEncoderDecoder -> ColumnTypes.Inet),
+
     classOf[java.util.Date] -> (TimestampWithTimezoneEncoderDecoder -> ColumnTypes.TimestampWithTimezone),
     classOf[java.sql.Date] -> ( DateEncoderDecoder -> ColumnTypes.Date ),
     classOf[java.sql.Time] -> ( SQLTimeEncoder -> ColumnTypes.Time ),

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/MessageDecoderSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/MessageDecoderSpec.scala
@@ -31,7 +31,7 @@ class MessageDecoderSpec extends Specification {
 
   "message decoder" should {
 
-    "not try to decode if there is not enought data available" in {
+    "not try to decode if there is not enough data available" in {
 
       val buffer = Unpooled.buffer()
 
@@ -44,7 +44,7 @@ class MessageDecoderSpec extends Specification {
       out.isEmpty
     }
 
-    "should not try to decode if there is a type and lenght but it's not long enough" in {
+    "should not try to decode if there is a type and length but it's not long enough" in {
 
       val buffer = Unpooled.buffer()
 


### PR DESCRIPTION
This does not support cidrs or inet values that have subnets as there is no obvious support for net masks in java.net, but does support IPv4 and IPv6.  Since InetEncoderDecoder is quite generic, put it in db-async-common.
