### PR TITLE
Improve URL parser to allow missing hostname/dbname

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
@@ -21,7 +21,7 @@ object ParserURL {
 
   val DEFAULT_PORT = "5432"
 
-  private val pgurl1 = """(jdbc:postgresql)://([^:]*|\[.+\])(?::(\d+))?/([^?]+)(?:\?user=(.*)&password=(.*))?""".r
+  private val pgurl1 = """(jdbc:postgresql):(?://([^/:]*|\[.+\])(?::(\d+))?)?(?:/([^/?]*))?(?:\?user=(.*)&password=(.*))?""".r
   private val pgurl2 = """(postgres|postgresql)://(.*):(.*)@(.*):(\d+)/(.*)""".r
 
   def parse(connectionURL: String): Map[String, String] = {
@@ -29,7 +29,9 @@ object ParserURL {
 
     connectionURL match {
       case pgurl1(protocol, server, port, dbname, username, password) => {
-        var result = properties + (PGHOST -> unwrapIpv6address(server)) + (PGDBNAME -> dbname)
+        var result = properties
+        if (server != null) result += (PGHOST -> unwrapIpv6address(server))
+        if (dbname != null && dbname.nonEmpty) result += (PGDBNAME -> dbname)
         if(port != null) result += (PGPORT -> port)
         if(username != null) result = (result + (PGUSERNAME -> username) + (PGPASSWORD -> password))
         result

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/URLParser.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/URLParser.scala
@@ -38,7 +38,7 @@ object URLParser {
       username = properties.get(Username).getOrElse(Default.username),
       password = properties.get(Password),
       database = properties.get(ParserURL.PGDBNAME),
-      host = properties(ParserURL.PGHOST),
+      host = properties.getOrElse(ParserURL.PGHOST, Default.host),
       port = port,
       charset = charset
     )

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/util/URLParserSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/util/URLParserSpec.scala
@@ -124,6 +124,54 @@ class URLParserSpec extends Specification {
       configuration.port === 9987
     }
 
+    "create a connection with a missing hostname" in {
+      val connectionUri = "jdbc:postgresql:/my_database?user=john&password=doe"
+
+      val configuration = URLParser.parse(connectionUri)
+
+      configuration.username === "john"
+      configuration.password === Some("doe")
+      configuration.database === Some("my_database")
+      configuration.host === "localhost"
+      configuration.port === 5432
+    }
+
+    "create a connection with a missing database name" in {
+      val connectionUri = "jdbc:postgresql://[::1]:9987/?user=john&password=doe"
+
+      val configuration = URLParser.parse(connectionUri)
+
+      configuration.username === "john"
+      configuration.password === Some("doe")
+      configuration.database === None
+      configuration.host === "::1"
+      configuration.port === 9987
+    }
+
+    "create a connection with all default fields" in {
+      val connectionUri = "jdbc:postgresql:"
+
+      val configuration = URLParser.parse(connectionUri)
+
+      configuration.username === "postgres"
+      configuration.password === None
+      configuration.database === None
+      configuration.host === "localhost"
+      configuration.port === 5432
+    }
+
+    "create a connection with an empty (invalid) url" in {
+      val connectionUri = ""
+
+      val configuration = URLParser.parse(connectionUri)
+
+      configuration.username === "postgres"
+      configuration.password === None
+      configuration.database === None
+      configuration.host === "localhost"
+      configuration.port === 5432
+    }
+
   }
 
 }


### PR DESCRIPTION
When parsing the URL "jdbc:postgresql:" (which is valid, or any invalid URL as well) URL parser would crash on line 41 trynig to get PGHOST from the map.  Fixed this, and also improved the parser to allow more valid URLs that are missing the host or dbname part.
