### PR TITLE
use netty PooledByteBufAllocator by default

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
@@ -20,6 +20,8 @@ import java.nio.charset.Charset
 import scala.Predef._
 import scala.{None, Option, Int}
 import io.netty.util.CharsetUtil
+import io.netty.buffer.AbstractByteBufAllocator
+import io.netty.buffer.PooledByteBufAllocator
 
 object Configuration {
   val DefaultCharset = CharsetUtil.UTF_8
@@ -49,5 +51,6 @@ case class Configuration(username: String,
                          password: Option[String] = None,
                          database: Option[String] = None,
                          charset: Charset = Configuration.DefaultCharset,
-                         maximumMessageSize: Int = 16777216
+                         maximumMessageSize: Int = 16777216,
+                         allocator: AbstractByteBufAllocator = PooledByteBufAllocator.DEFAULT
                           )

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
@@ -90,6 +90,7 @@ class PostgreSQLConnectionHandler
     })
 
     this.bootstrap.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
+    this.bootstrap.option(ChannelOption.ALLOCATOR, configuration.allocator)
 
     this.bootstrap.connect(new InetSocketAddress(configuration.host, configuration.port)).onFailure {
       case e => connectionFuture.tryFailure(e)


### PR DESCRIPTION
Looks like by default netty uses an unpooled byte buffer allocator that creates a blocking behavior. This is the monitor usage from yourkit:

![captura de tela 2013-12-11 as 12 34 41 am](https://f.cloud.github.com/assets/831175/1719984/1f9c6b28-61f6-11e3-8b1b-7743546983bb.png)

Using the pooled version, the blocking bottleneck is solved:

![captura de tela 2013-12-11 as 12 47 28 am](https://f.cloud.github.com/assets/831175/1719998/5b0fac10-61f6-11e3-8e67-c071142eaa1a.png)
