### PR TITLE
named executors

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/DaemonThreadsFactory.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/DaemonThreadsFactory.scala
@@ -16,14 +16,18 @@
 
 package com.github.mauricio.async.db.util
 
-import java.util.concurrent.{Executors, ThreadFactory}
+import java.util.concurrent.{ Executors, ThreadFactory }
+import java.util.concurrent.atomic.AtomicInteger
 
-object DaemonThreadsFactory extends ThreadFactory {
+case class DaemonThreadsFactory(name: String) extends ThreadFactory {
+
+  private val threadNumber = new AtomicInteger(1)
+
   def newThread(r: Runnable): Thread = {
-
     val thread = Executors.defaultThreadFactory().newThread(r)
     thread.setDaemon(true)
-
-    return thread
+    val threadName = name + "-thread-" + threadNumber.getAndIncrement
+    thread.setName(threadName)
+    thread
   }
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/ExecutorServiceUtils.scala
@@ -20,11 +20,11 @@ import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.ExecutionContext
 
 object ExecutorServiceUtils {
-  implicit val CachedThreadPool = Executors.newCachedThreadPool(DaemonThreadsFactory)
+  implicit val CachedThreadPool = Executors.newCachedThreadPool(DaemonThreadsFactory("db-async-default"))
   implicit val CachedExecutionContext = ExecutionContext.fromExecutor( CachedThreadPool )
 
-  def newFixedPool( count : Int ) : ExecutorService = {
-    Executors.newFixedThreadPool( count, DaemonThreadsFactory )
+  def newFixedPool( count : Int, name: String ) : ExecutorService = {
+    Executors.newFixedThreadPool( count, DaemonThreadsFactory(name) )
   }
 
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/NettyUtils.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/NettyUtils.scala
@@ -21,6 +21,6 @@ import io.netty.util.internal.logging.{InternalLoggerFactory, Slf4JLoggerFactory
 object NettyUtils {
 
   InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory())
-  lazy val DefaultEventLoopGroup = new NioEventLoopGroup(0, DaemonThreadsFactory)
+  lazy val DefaultEventLoopGroup = new NioEventLoopGroup(0, DaemonThreadsFactory("db-async-netty"))
 
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/util/Worker.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/util/Worker.scala
@@ -22,7 +22,7 @@ import scala.concurrent.{ExecutionContextExecutorService, ExecutionContext}
 object Worker {
   val log = Log.get[Worker]
 
-  def apply() : Worker = apply(ExecutorServiceUtils.newFixedPool(1))
+  def apply() : Worker = apply(ExecutorServiceUtils.newFixedPool(1, "db-async-worker"))
 
   def apply( executorService : ExecutorService ) : Worker = {
     new Worker(ExecutionContext.fromExecutorService( executorService ))


### PR DESCRIPTION
It is difficult to identify which threads are created by the driver. This PR adds names to the executors, so we can trace where threads are created.
