### PR TITLE
reproduce error when selecting bind variables

### DIFF
--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PreparedStatementSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PreparedStatementSpec.scala
@@ -244,6 +244,14 @@ class PreparedStatementSpec extends Specification with DatabaseTestHelper {
 
     }
 
+    "support select bind value" in {
+        withHandler {
+            handler =>
+                val string = "someString"
+                val result = executePreparedStatement(handler, "SELECT ?", Array(string)).rows.get
+                result(0)(0) == string
+        }
+    }.pendingUntilFixed("select bind values")
   }
 
 }


### PR DESCRIPTION
This is the error thrown by the test:

GenericDatabaseException: : ErrorMessage(fields=Map(Line -> 1300, File -> postgres.c, SQLSTATE -> 42P18, Routine -> exec_parse_message, Message -> could not determine data type of parameter $1, Severity -> ERROR))  (PostgreSQLConnection.scala:167)