### PR TITLE
Creating a unique named log per connection causes memory leak

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -60,7 +60,7 @@ class PostgreSQLConnection
     executionContext
   )
   private final val currentCount = Counter.incrementAndGet()
-  private final val log = Log.getByName(s"${this.getClass.getName}:${currentCount}")
+  private final val log = Log.getByName(s"${this.getClass.getName}")
   private final val preparedStatementsCounter = new AtomicInteger()
   private final implicit val internalExecutionContext = executionContext
 


### PR DESCRIPTION
We had been experiencing a slow memory leak using postgresql-async within Play.  We tracked it down to the unique named log created when the PostgreSQLConnection is constructed.  Although the PostgreSQLConnection is destructed properly, the logging framework holds on to a reference to the logger which was created.  Overtime these build up an are never released.  
