### PR TITLE
If the parameter provided to a SQL query is of wrong type, the next identical query with a correct type also fails.

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -150,6 +150,7 @@ class PostgreSQLConnection
       this.disconnect
     }
 
+    this.currentPreparedStatement.map(p => this.parsedStatements.remove(p.query))
     this.currentPreparedStatement = None
     this.failQueryPromise(e)
   }

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PreparedStatementHolder.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PreparedStatementHolder.scala
@@ -18,7 +18,7 @@ package com.github.mauricio.async.db.postgresql
 
 import com.github.mauricio.async.db.postgresql.messages.backend.PostgreSQLColumnData
 
-class PreparedStatementHolder( query : String, val statementId : Int ) {
+class PreparedStatementHolder(val query : String, val statementId : Int ) {
 
   val (realQuery, paramsCount) = {
     val result = new StringBuilder(query.length+16)


### PR DESCRIPTION
If query `SELECT content FROM messages WHERE id = ?` (where id is bigint) is send with a `String` parameter : the method throw a GenericDatabaseException => OK

But after, if a second identical query is send with a correct number value : the method throw an `ArrayIndexOutOfBoundsException: : 0  (PostgreSQLConnection.scala:194)` => KO
