### PR TITLE
A query without return keep return value of previous query

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -303,6 +303,7 @@ class PostgreSQLConnection
 
   private def succeedQueryPromise(result: QueryResult) {
     this.queryResult = None
+    this.currentQuery = None
     this.clearQueryPromise.foreach {
       _.success(result)
     }

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnectionSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnectionSpec.scala
@@ -428,6 +428,20 @@ class PostgreSQLConnectionSpec extends Specification with DatabaseTestHelper {
 
     }
 
+    "insert without return after select" in {
+
+      withHandler {
+        handler =>
+          executeDdl(handler, this.preparedStatementCreate)
+          executeDdl(handler, this.preparedStatementInsert, 1)
+          executeDdl(handler, this.preparedStatementSelect, 1)
+          val result = executeQuery(handler, this.preparedStatementInsert2)
+
+          result.rows === None
+      }
+
+    }
+
   }
 
 }


### PR DESCRIPTION
E.g. insert without return after a select = > return value of the select. 
