### PR TITLE
Fix encoding of backslashes in arrays

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
@@ -131,7 +131,7 @@ class PostgreSQLColumnEncoderRegistry extends ColumnEncoderRegistry {
           "NULL"
         } else {
           if (this.shouldQuote(item)) {
-            "\"" + this.encode(item).replaceAllLiterally("\"", """\"""") + "\""
+            "\"" + this.encode(item).replaceAllLiterally("\\", """\\""").replaceAllLiterally("\"", """\"""") + "\""
           } else {
             this.encode(item)
           }

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/ArrayTypesSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/ArrayTypesSpec.scala
@@ -34,7 +34,7 @@ class ArrayTypesSpec extends Specification with DatabaseTestHelper {
       (smallint_column, text_column, timestamp_column)
       values (
       '{1,2,3,4}',
-      '{"some,\"comma,separated,text","another line of text",NULL}',
+      '{"some,\"comma,separated,text","another line of text","fake\,backslash","real\\,backslash\\",NULL}',
       '{"2013-04-06 01:15:10.528-03","2013-04-06 01:15:08.528-03"}'
       )"""
 
@@ -52,7 +52,7 @@ class ArrayTypesSpec extends Specification with DatabaseTestHelper {
           executeDdl(handler, insert, 1)
           val result = executeQuery(handler, "select * from type_test_table").rows.get
           result(0)("smallint_column") === List(1,2,3,4)
-          result(0)("text_column") === List("some,\"comma,separated,text", "another line of text", null )
+          result(0)("text_column") === List("some,\"comma,separated,text", "another line of text", "fake,backslash", "real\\,backslash\\", null )
           result(0)("timestamp_column") === List(
             TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:10.528-03"),
             TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:08.528-03")
@@ -68,7 +68,7 @@ class ArrayTypesSpec extends Specification with DatabaseTestHelper {
         TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:08.528-03")
       )
       val numbers = List(1,2,3,4)
-      val texts = List("some,\"comma,separated,text", "another line of text", null )
+      val texts = List("some,\"comma,separated,text", "another line of text", "fake,backslash", "real\\,backslash\\", null )
 
       withHandler {
         handler =>

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/column/DefaultColumnEncoderRegistrySpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/column/DefaultColumnEncoderRegistrySpec.scala
@@ -26,7 +26,7 @@ class DefaultColumnEncoderRegistrySpec extends Specification {
 
     "correctly render an array of strings with nulls" in {
       val items = Array( "some", """text \ hoes " here to be seen""", null, "all, right" )
-      registry.encode( items ) === """{"some","text \ hoes \" here to be seen",NULL,"all, right"}"""
+      registry.encode( items ) === """{"some","text \\ hoes \" here to be seen",NULL,"all, right"}"""
     }
 
     "correctly render an array of numbers" in {


### PR DESCRIPTION
Backslashes were not getting correctly escaped when encoding into arrays.  Any `Seq[String]` put into the database would lose all its backslashes.  This fixes it and updates the tests to catch it.
