### PR TITLE
Consistently use implicit ExecutionContext

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/Connection.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/Connection.scala
@@ -16,7 +16,7 @@
 
 package com.github.mauricio.async.db
 
-import concurrent.Future
+import concurrent.{ExecutionContext, Future}
 
 /**
  *
@@ -43,6 +43,8 @@ import concurrent.Future
  */
 
 trait Connection {
+
+  implicit val executionContext: ExecutionContext
 
   /**
    *
@@ -124,7 +126,7 @@ trait Connection {
    * @return result of f, conditional on transaction operations succeeding
    */
 
-  def inTransaction[A](f : Connection => Future[A])(implicit executionContext : scala.concurrent.ExecutionContext) : Future[A] = {
+  def inTransaction[A](f : Connection => Future[A]) : Future[A] = {
     this.sendQuery("BEGIN").flatMap { _ =>
       val p = scala.concurrent.Promise[A]()
       f(this).onComplete { r =>

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/AsyncObjectPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/AsyncObjectPool.scala
@@ -29,6 +29,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait AsyncObjectPool[T] {
 
+  implicit val executionContext: ExecutionContext
+
   /**
    *
    * Returns an object from the pool to the callee with the returned future. If the pool can not create or enqueue
@@ -70,7 +72,7 @@ trait AsyncObjectPool[T] {
    * @return f wrapped with take and giveBack
    */
 
-  def use[A](f: (T) => Future[A])(implicit executionContext: ExecutionContext): Future[A] =
+  def use[A](f: (T) => Future[A]): Future[A] =
     take.flatMap { item =>
       f(item) recoverWith {
         case error => giveBack(item).flatMap(_ => Future.failed(error))

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/ConnectionPool.scala
@@ -38,10 +38,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConnectionPool[T <: Connection](
                       factory: ObjectFactory[T],
-                      configuration: PoolConfiguration,
-                      executionContext: ExecutionContext = ExecutorServiceUtils.CachedExecutionContext
-                      )
-  extends SingleThreadedAsyncObjectPool[T](factory, configuration)
+                      configuration: PoolConfiguration)(
+                      implicit executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext)
+  extends SingleThreadedAsyncObjectPool[T](factory, configuration)(executionContext)
   with Connection {
 
   /**
@@ -52,7 +51,7 @@ class ConnectionPool[T <: Connection](
    */
 
   def disconnect: Future[Connection] = if ( this.isConnected ) {
-    this.close.map(item => this)(executionContext)
+    this.close.map(item => this)
   } else {
     Future.successful(this)
   }
@@ -79,7 +78,7 @@ class ConnectionPool[T <: Connection](
    */
 
   def sendQuery(query: String): Future[QueryResult] =
-    this.use(_.sendQuery(query))(executionContext)
+    this.use(_.sendQuery(query))
 
   /**
    *
@@ -93,7 +92,7 @@ class ConnectionPool[T <: Connection](
    */
 
   def sendPreparedStatement(query: String, values: Seq[Any] = List()): Future[QueryResult] =
-    this.use(_.sendPreparedStatement(query, values))(executionContext)
+    this.use(_.sendPreparedStatement(query, values))
 
   /**
    *
@@ -105,7 +104,7 @@ class ConnectionPool[T <: Connection](
    * @return result of f, conditional on transaction operations succeeding
    */
 
-  override def inTransaction[A](f : Connection => Future[A])(implicit context : ExecutionContext = executionContext) : Future[A] =
-    this.use(_.inTransaction[A](f)(context))(executionContext)
+  override def inTransaction[A](f : Connection => Future[A]): Future[A] =
+    this.use(_.inTransaction[A](f))
 
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPool.scala
@@ -1,8 +1,6 @@
 package com.github.mauricio.async.db.pool
 
-import scala.concurrent.Future
-import com.github.mauricio.async.db.util.ExecutorServiceUtils
-import scala.concurrent.Promise
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import java.util.concurrent.ConcurrentHashMap
 import scala.util.Success
 import scala.util.Failure
@@ -10,10 +8,9 @@ import scala.util.Failure
 class PartitionedAsyncObjectPool[T](
     factory: ObjectFactory[T],
     configuration: PoolConfiguration,
-    numberOfPartitions: Int)
+    numberOfPartitions: Int)(
+    implicit val executionContext: ExecutionContext)
     extends AsyncObjectPool[T] {
-
-    import ExecutorServiceUtils.CachedExecutionContext
 
     private val pools =
         (0 until numberOfPartitions)

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedConnectionPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PartitionedConnectionPool.scala
@@ -2,18 +2,18 @@ package com.github.mauricio.async.db.pool;
 
 import com.github.mauricio.async.db.util.ExecutorServiceUtils
 import com.github.mauricio.async.db.{ QueryResult, Connection }
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 class PartitionedConnectionPool[T <: Connection](
     factory: ObjectFactory[T],
     configuration: PoolConfiguration,
-    numberOfPartitions: Int,
-    executionContext: ExecutionContext = ExecutorServiceUtils.CachedExecutionContext)
-    extends PartitionedAsyncObjectPool[T](factory, configuration, numberOfPartitions)
+    numberOfPartitions: Int)(
+    implicit executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext)
+    extends PartitionedAsyncObjectPool[T](factory, configuration, numberOfPartitions)(executionContext)
     with Connection {
 
     def disconnect: Future[Connection] = if (this.isConnected) {
-        this.close.map(item => this)(executionContext)
+        this.close.map(item => this)
     } else {
         Future.successful(this)
     }
@@ -23,11 +23,11 @@ class PartitionedConnectionPool[T <: Connection](
     def isConnected: Boolean = !this.isClosed
 
     def sendQuery(query: String): Future[QueryResult] =
-        this.use(_.sendQuery(query))(executionContext)
+        this.use(_.sendQuery(query))
 
     def sendPreparedStatement(query: String, values: Seq[Any] = List()): Future[QueryResult] =
-        this.use(_.sendPreparedStatement(query, values))(executionContext)
+        this.use(_.sendPreparedStatement(query, values))
 
-    override def inTransaction[A](f: Connection => Future[A])(implicit context: ExecutionContext = executionContext): Future[A] =
-        this.use(_.inTransaction[A](f)(context))(executionContext)
+    override def inTransaction[A](f: Connection => Future[A]): Future[A] =
+        this.use(_.inTransaction[A](f))
 }

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/SingleThreadedAsyncObjectPool.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/SingleThreadedAsyncObjectPool.scala
@@ -20,7 +20,7 @@ import com.github.mauricio.async.db.util.{Log, Worker}
 import java.util.concurrent.atomic.AtomicLong
 import java.util.{TimerTask, Timer}
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.{Promise, Future}
+import scala.concurrent.{ExecutionContext, Promise, Future}
 import scala.util.{Failure, Success}
 
 object SingleThreadedAsyncObjectPool {
@@ -44,7 +44,9 @@ object SingleThreadedAsyncObjectPool {
 class SingleThreadedAsyncObjectPool[T](
                                         factory: ObjectFactory[T],
                                         configuration: PoolConfiguration
-                                        ) extends AsyncObjectPool[T] {
+                                        )(
+                                        implicit val executionContext : ExecutionContext)
+  extends AsyncObjectPool[T] {
 
   import SingleThreadedAsyncObjectPool.{Counter, log}
 

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
@@ -41,8 +41,8 @@ object MySQLConnection {
 class MySQLConnection(
                        configuration: Configuration,
                        charsetMapper: CharsetMapper = CharsetMapper.Instance,
-                       group : EventLoopGroup = NettyUtils.DefaultEventLoopGroup,
-                       executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext
+                       group : EventLoopGroup = NettyUtils.DefaultEventLoopGroup)(
+                       implicit val executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext
                        )
   extends MySQLHandlerDelegate
   with Connection
@@ -56,14 +56,12 @@ class MySQLConnection(
 
   private final val connectionCount = MySQLConnection.Counter.incrementAndGet()
   private final val connectionId = s"[mysql-connection-$connectionCount]"
-  private implicit val internalPool = executionContext
 
   private final val connectionHandler = new MySQLConnectionHandler(
     configuration,
     charsetMapper,
     this,
     group,
-    executionContext,
     connectionId)
 
   private final val connectionPromise = Promise[Connection]()

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
@@ -43,12 +43,10 @@ class MySQLConnectionHandler(
                               charsetMapper: CharsetMapper,
                               handlerDelegate: MySQLHandlerDelegate,
                               group : EventLoopGroup,
-                              executionContext : ExecutionContext,
-                              connectionId : String
-                              )
+                              connectionId : String)(
+                              implicit executionContext : ExecutionContext)
   extends SimpleChannelInboundHandler[Object] {
 
-  private implicit val internalPool = executionContext
   private final val log = Log.getByName(s"[connection-handler]${connectionId}")
   private final val bootstrap = new Bootstrap().group(this.group)
   private final val connectionPromise = Promise[MySQLConnectionHandler]

--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/MySQLConnectionSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/MySQLConnectionSpec.scala
@@ -31,7 +31,7 @@ class MySQLConnectionSpec extends Specification {
   )
 
   val rootConfiguration = new Configuration(
-    "root",
+    "mysql_async_nopw",
     "localhost",
     port = 3306,
     password = None,
@@ -39,7 +39,7 @@ class MySQLConnectionSpec extends Specification {
   )
 
   val configurationWithoutDatabase = new Configuration(
-    "root",
+    "mysql_async_nopw",
     "localhost",
     port = 3306,
     password = None,

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -44,8 +44,8 @@ class PostgreSQLConnection
   configuration: Configuration = Configuration.Default,
   encoderRegistry: ColumnEncoderRegistry = PostgreSQLColumnEncoderRegistry.Instance,
   decoderRegistry: ColumnDecoderRegistry = PostgreSQLColumnDecoderRegistry.Instance,
-  group : EventLoopGroup = NettyUtils.DefaultEventLoopGroup,
-  executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext
+  group : EventLoopGroup = NettyUtils.DefaultEventLoopGroup)(
+  implicit val executionContext : ExecutionContext = ExecutorServiceUtils.CachedExecutionContext
   )
   extends PostgreSQLConnectionDelegate
   with Connection {
@@ -57,13 +57,11 @@ class PostgreSQLConnection
     encoderRegistry,
     decoderRegistry,
     this,
-    group,
-    executionContext
+    group
   )
 
   private final val currentCount = Counter.incrementAndGet()
   private final val preparedStatementsCounter = new AtomicInteger()
-  private final implicit val internalExecutionContext = executionContext
 
   private val parameterStatus = new scala.collection.mutable.HashMap[String, String]()
   private val parsedStatements = new scala.collection.mutable.HashMap[String, PreparedStatementHolder]()

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
@@ -49,8 +49,8 @@ class PostgreSQLConnectionHandler
   encoderRegistry: ColumnEncoderRegistry,
   decoderRegistry: ColumnDecoderRegistry,
   connectionDelegate : PostgreSQLConnectionDelegate,
-  group : EventLoopGroup,
-  executionContext : ExecutionContext
+  group : EventLoopGroup)(
+  implicit executionContext : ExecutionContext
   )
   extends SimpleChannelInboundHandler[Object]
 {
@@ -64,7 +64,6 @@ class PostgreSQLConnectionHandler
     "DateStyle" -> "ISO",
     "extra_float_digits" -> "2")
 
-  private implicit final val _executionContext = executionContext
   private final val bootstrap = new Bootstrap()
   private final val connectionFuture = Promise[PostgreSQLConnectionHandler]()
   private final val disconnectionPromise = Promise[PostgreSQLConnectionHandler]()

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
@@ -49,7 +49,7 @@ class PostgreSQLConnectionFactory(
   import PostgreSQLConnectionFactory.log
 
   def create: PostgreSQLConnection = {
-    val connection = new PostgreSQLConnection(configuration, group = group, executionContext = executionContext)
+    val connection = new PostgreSQLConnection(configuration, group = group)(executionContext)
     Await.result(connection.connect, configuration.connectTimeout)
 
     connection

--- a/script/prepare_build.sh
+++ b/script/prepare_build.sh
@@ -5,6 +5,7 @@ mysql -u root -e 'create database mysql_async_tests;'
 mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'mysql_async'@'localhost' IDENTIFIED BY 'root' WITH GRANT OPTION";
 mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'mysql_async_old'@'localhost' WITH GRANT OPTION";
 mysql -u root -e "UPDATE mysql.user SET Password = OLD_PASSWORD('do_not_use_this'), plugin = 'mysql_old_password' where User = 'mysql_async_old'; flush privileges;";
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'mysql_async_nopw'@'localhost' WITH GRANT OPTION";
 
 echo "preparing postgresql configs"
 


### PR DESCRIPTION
This is a refactoring which I found out when trying to implement chunked BLOB sending. This is independent from chunked BLOB sending though, feel free to merge it if you agree it is an improvment.