### PR TITLE
TimeAndDateSpec should test LocalTime printing/encoding

### DIFF
--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/TimeAndDateSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/TimeAndDateSpec.scala
@@ -35,7 +35,7 @@ class TimeAndDateSpec extends Specification with DatabaseTestHelper {
                          )"""
 
           executeDdl(handler, create)
-          executeQuery(handler, "INSERT INTO messages (moment) VALUES ('04:05:06')")
+          executePreparedStatement(handler, "INSERT INTO messages (moment) VALUES (?)", Array[Any](new LocalTime(4, 5, 6)))
 
           val rows = executePreparedStatement(handler, "select * from messages").rows.get
 
@@ -60,7 +60,7 @@ class TimeAndDateSpec extends Specification with DatabaseTestHelper {
                          )"""
 
           executeDdl(handler, create)
-          executeQuery(handler, "INSERT INTO messages (moment) VALUES ('04:05:06.134')")
+          executePreparedStatement(handler, "INSERT INTO messages (moment) VALUES (?)", Array[Any](new LocalTime(4, 5, 6, 134)))
 
           val rows = executePreparedStatement(handler, "select * from messages").rows.get
 


### PR DESCRIPTION
Prepared statement should be used so that the encoder is actually tested.

This should demonstrate issue #142.