### PR TITLE
Change queryTimeout to be infinite by default

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
@@ -55,4 +55,4 @@ case class Configuration(username: String,
                          allocator: AbstractByteBufAllocator = PooledByteBufAllocator.DEFAULT,
                          connectTimeout: Duration = 5.seconds,
                          testTimeout: Duration = 5.seconds,
-                         requestTimeout: Duration = 5.seconds)
+                         queryTimeout: Duration = Duration.Inf)

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/MySQLConnection.scala
@@ -248,7 +248,9 @@ class MySQLConnection(
     val promise = Promise[QueryResult]()
     this.setQueryPromise(promise)
     this.connectionHandler.sendPreparedStatement(query, values)
-    addTimeout(promise)
+    if (configuration.queryTimeout != Duration.Inf) {
+      addTimeout(promise)
+    }
 
     promise.future
   }


### PR DESCRIPTION
Current implementation is using 5 seconds by default. This change can pose backward compatibility issues for existing usages 