### PR TITLE
Add timeout support for queries

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
@@ -54,4 +54,5 @@ case class Configuration(username: String,
                          maximumMessageSize: Int = 16777216,
                          allocator: AbstractByteBufAllocator = PooledByteBufAllocator.DEFAULT,
                          connectTimeout: Duration = 5.seconds,
-                         testTimeout: Duration = 5.seconds)
+                         testTimeout: Duration = 5.seconds,
+                         queryTimeout: Duration = Duration.Inf)

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/exceptions/ConnectionTimeoutedException.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/exceptions/ConnectionTimeoutedException.scala
@@ -1,0 +1,6 @@
+package com.github.mauricio.async.db.exceptions
+
+import com.github.mauricio.async.db.Connection
+
+class ConnectionTimeoutedException( val connection : Connection )
+  extends DatabaseException( "The connection %s has a timeouted query and is being closed".format(connection) )

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/TimeoutScheduler.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/TimeoutScheduler.scala
@@ -1,0 +1,37 @@
+package com.github.mauricio.async.db.pool
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{TimeUnit, TimeoutException, ScheduledFuture}
+import com.github.mauricio.async.db.util.NettyUtils
+import scala.concurrent.{ExecutionContext, Promise}
+import scala.concurrent.duration.Duration
+
+trait TimeoutScheduler {
+  implicit val internalPool: ExecutionContext
+  def onTimeout    // implementors should decide here what they want to do when a timeout occur
+  private var isTimeoutedBool = new AtomicBoolean(false);
+  def isTimeouted = isTimeoutedBool.get // We need this property as isClosed takes time to complete and
+          // we don't want the connection to be used again.
+
+  def addTimeout[A](promise: Promise[A], duration: Duration) : Option[ScheduledFuture[_]] = {
+    if (duration != Duration.Inf) {
+      val scheduledFuture = schedule(
+        {
+          if (promise.tryFailure(new TimeoutException(s"Operation is timeouted after it took too long to return (${duration})"))) {
+            isTimeoutedBool.set(true)
+            onTimeout
+          }
+        },
+        duration)
+      promise.future.onComplete(x => scheduledFuture.cancel(false))
+
+      return Some(scheduledFuture)
+    }
+    return None
+  }
+
+  def schedule(block: => Unit, duration: Duration) : ScheduledFuture[_] =
+    NettyUtils.DefaultEventLoopGroup.schedule(new Runnable {
+      override def run(): Unit = block
+    }, duration.toMillis, TimeUnit.MILLISECONDS)
+}

--- a/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/DummyTimeoutScheduler.scala
+++ b/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/DummyTimeoutScheduler.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.mauricio.async.db.pool
+
+import java.util.concurrent.atomic.AtomicInteger
+import com.github.mauricio.async.db.util.ExecutorServiceUtils
+/**
+ * Implementation of TimeoutScheduler used for testing
+ */
+class DummyTimeoutScheduler extends TimeoutScheduler {
+  implicit val internalPool = ExecutorServiceUtils.CachedExecutionContext
+  private val timeOuts = new AtomicInteger
+  override def onTimeout = timeOuts.incrementAndGet
+  def timeoutCount = timeOuts.get()
+}

--- a/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPoolSpec.scala
+++ b/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/PartitionedAsyncObjectPoolSpec.scala
@@ -1,5 +1,7 @@
 package com.github.mauricio.async.db.pool
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.specs2.mutable.Specification
 import scala.util.Try
 import scala.concurrent.Await
@@ -17,17 +19,16 @@ class PartitionedAsyncObjectPoolSpec extends SpecificationWithJUnit {
 
     val config =
         PoolConfiguration(100, Long.MaxValue, 100, Int.MaxValue)
-
+    private var current = new AtomicInteger
     val factory = new ObjectFactory[Int] {
         var reject = Set[Int]()
         var failCreate = false
-        private var current = 0
+
         def create =
             if (failCreate)
                 throw new IllegalStateException
             else {
-                current += 1
-                current
+                current.incrementAndGet()
             }
         def destroy(item: Int) = {}
         def validate(item: Int) =

--- a/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/TimeoutSchedulerSpec.scala
+++ b/db-async-common/src/test/scala/com/github/mauricio/async/db/pool/TimeoutSchedulerSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.mauricio.async.db.pool
+
+import java.util.concurrent.{ScheduledFuture, TimeoutException}
+import com.github.mauricio.async.db.util.{ByteBufferUtils, ExecutorServiceUtils}
+import org.specs2.mutable.SpecificationWithJUnit
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Tests for TimeoutScheduler
+ */
+class TimeoutSchedulerSpec extends SpecificationWithJUnit  {
+
+  val TIMEOUT_DID_NOT_PASS = "timeout did not pass"
+
+
+  "test timeout did not pass" in {
+    val timeoutScheduler = new DummyTimeoutScheduler()
+    val promise = Promise[String]()
+    val scheduledFuture  = timeoutScheduler.addTimeout(promise,Duration(1000, MILLISECONDS))
+    Thread.sleep(100);
+    promise.isCompleted === false
+    promise.success(TIMEOUT_DID_NOT_PASS)
+    Thread.sleep(1500)
+    promise.future.value.get.get === TIMEOUT_DID_NOT_PASS
+    scheduledFuture.get.isCancelled === true
+    timeoutScheduler.timeoutCount === 0
+  }
+
+  "test timeout passed" in {
+    val timeoutMillis = 100
+    val promise = Promise[String]()
+    val timeoutScheduler = new DummyTimeoutScheduler()
+    val scheduledFuture  = timeoutScheduler.addTimeout(promise,Duration(timeoutMillis, MILLISECONDS))
+    Thread.sleep(1000)
+    promise.isCompleted === true
+    scheduledFuture.get.isCancelled === false
+    promise.trySuccess(TIMEOUT_DID_NOT_PASS)
+    timeoutScheduler.timeoutCount === 1
+    promise.future.value.get.get must throwA[TimeoutException](message = s"Operation is timeouted after it took too long to return \\(${timeoutMillis} milliseconds\\)")
+  }
+
+
+  "test no timeout" in {
+    val timeoutScheduler = new DummyTimeoutScheduler()
+    val promise = Promise[String]()
+    val scheduledFuture  = timeoutScheduler.addTimeout(promise,Duration.Inf)
+    Thread.sleep(1000)
+    scheduledFuture === None
+    promise.isCompleted === false
+    promise.success(TIMEOUT_DID_NOT_PASS)
+    promise.future.value.get.get === TIMEOUT_DID_NOT_PASS
+    timeoutScheduler.timeoutCount === 0
+  }
+}
+

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/pool/MySQLConnectionFactory.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/pool/MySQLConnectionFactory.scala
@@ -21,9 +21,8 @@ import com.github.mauricio.async.db.pool.ObjectFactory
 import com.github.mauricio.async.db.mysql.MySQLConnection
 import scala.util.Try
 import scala.concurrent.Await
-import scala.concurrent.duration._
 import com.github.mauricio.async.db.util.Log
-import com.github.mauricio.async.db.exceptions.{ConnectionStillRunningQueryException, ConnectionNotConnectedException}
+import com.github.mauricio.async.db.exceptions.{ConnectionTimeoutedException, ConnectionStillRunningQueryException, ConnectionNotConnectedException}
 
 object MySQLConnectionFactory {
   final val log = Log.get[MySQLConnectionFactory]
@@ -90,7 +89,9 @@ class MySQLConnectionFactory( configuration : Configuration ) extends ObjectFact
    */
   def validate(item: MySQLConnection): Try[MySQLConnection] = {
     Try{
-
+      if ( item.isTimeouted ) {
+        throw new ConnectionTimeoutedException(item)
+      }
       if ( !item.isConnected ) {
         throw new ConnectionNotConnectedException(item)
       }

--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/ConnectionHelper.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/ConnectionHelper.scala
@@ -115,6 +115,19 @@ trait ConnectionHelper {
 
   }
 
+  def withConfigurablePool[T]( configuration : Configuration )( fn : (ConnectionPool[MySQLConnection]) => T ) : T = {
+
+    val factory = new MySQLConnectionFactory(configuration)
+    val pool = new ConnectionPool[MySQLConnection](factory, PoolConfiguration.Default)
+
+    try {
+      fn(pool)
+    } finally {
+      awaitFuture( pool.close )
+    }
+
+  }
+
   def withConnection[T]( fn : (MySQLConnection) => T ) : T =
     withConfigurableConnection(this.defaultConfiguration)(fn)
 

--- a/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/QueryTimeoutSpec.scala
+++ b/mysql-async/src/test/scala/com/github/mauricio/async/db/mysql/QueryTimeoutSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.mauricio.async.db.mysql
+
+import java.util.concurrent.TimeoutException
+import com.github.mauricio.async.db.Configuration
+import org.specs2.execute.{AsResult, Success, ResultExecution}
+import org.specs2.mutable.Specification
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class QueryTimeoutSpec extends Specification with ConnectionHelper {
+  implicit def unitAsResult: AsResult[Unit] = new AsResult[Unit] {
+    def asResult(r: =>Unit) =
+      ResultExecution.execute(r)(_ => Success())
+  }
+  "Simple query with 1 nanosec timeout" in {
+    withConfigurablePool(shortTimeoutConfiguration) {
+      pool => {
+        val connection = Await.result(pool.take, Duration(10,SECONDS))
+        connection.isTimeouted === false
+        connection.isConnected === true
+        val queryResultFuture = connection.sendQuery("select sleep(1)")
+        Await.result(queryResultFuture, Duration(10,SECONDS)) must throwA[TimeoutException]()
+        connection.isTimeouted === true
+        Await.ready(pool.giveBack(connection), Duration(10,SECONDS))
+        pool.availables.count(_ == connection) === 0 // connection removed from pool
+        // we do not know when the connection will be closed.
+      }
+    }
+  }
+
+  "Simple query with 5 sec timeout" in {
+    withConfigurablePool(longTimeoutConfiguration) {
+      pool => {
+        val connection = Await.result(pool.take, Duration(10,SECONDS))
+        connection.isTimeouted === false
+        connection.isConnected === true
+        val queryResultFuture = connection.sendQuery("select sleep(1)")
+        Await.result(queryResultFuture, Duration(10,SECONDS)).rows.get.size === 1
+        connection.isTimeouted === false
+        connection.isConnected === true
+        Await.ready(pool.giveBack(connection), Duration(10,SECONDS))
+        pool.availables.count(_ == connection) === 1 // connection returned to pool
+      }
+    }
+  }
+
+  def shortTimeoutConfiguration = new Configuration(
+    "mysql_async",
+    "localhost",
+    port = 3306,
+    password = Some("root"),
+    database = Some("mysql_async_tests"),
+    queryTimeout = Duration(1,NANOSECONDS)
+  )
+
+  def longTimeoutConfiguration = new Configuration(
+    "mysql_async",
+    "localhost",
+    port = 3306,
+    password = Some("root"),
+    database = Some("mysql_async_tests"),
+    queryTimeout = Duration(5,SECONDS)
+  )
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/pool/PostgreSQLConnectionFactory.scala
@@ -17,6 +17,7 @@
 package com.github.mauricio.async.db.postgresql.pool
 
 import com.github.mauricio.async.db.Configuration
+import com.github.mauricio.async.db.exceptions.ConnectionTimeoutedException
 import com.github.mauricio.async.db.pool.ObjectFactory
 import com.github.mauricio.async.db.postgresql.PostgreSQLConnection
 import com.github.mauricio.async.db.util.Log
@@ -69,6 +70,9 @@ class PostgreSQLConnectionFactory(
 
   def validate( item : PostgreSQLConnection ) : Try[PostgreSQLConnection] = {
     Try {
+      if ( item.isTimeouted ) {
+        throw new ConnectionTimeoutedException(item)
+      }
       if ( !item.isConnected || item.hasRecentError ) {
         throw new ClosedChannelException()
       } 


### PR DESCRIPTION
Added optional timeout to the connection configuration.
When a query does not return in the specified timeout it will be terminated and the connection will be closed releasing its underlying resources 