### PR TITLE
Added types field to MutableResultSet. This will allow inferring the …

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/general/MutableResultSet.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/general/MutableResultSet.scala
@@ -31,9 +31,11 @@ class MutableResultSet[T <: ColumnData](
   private val columnMapping: Map[String, Int] = this.columnTypes.indices.map(
     index =>
       ( this.columnTypes(index).name, index ) ).toMap
-    
+
 
   val columnNames : IndexedSeq[String] = this.columnTypes.map(c => c.name)
+
+  val types : IndexedSeq[Int] = this.columnTypes.map(c => c.dataType)
 
   override def length: Int = this.rows.length
 


### PR DESCRIPTION
…types of RowData fields, which can be useful in different situations, e.g. converting the results to json format