### PR TITLE
Error using NUMERIC columns with PreparedStatements in PostgreSQL

### DIFF
--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/NumericSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/NumericSpec.scala
@@ -1,0 +1,57 @@
+package com.github.mauricio.async.db.postgresql
+
+import org.specs2.mutable.Specification
+
+class NumericSpec extends Specification with DatabaseTestHelper {
+
+  "when processing numeric columns" should {
+
+    "support first update of num column with floating" in {
+
+      withHandler {
+        handler =>
+          executeDdl(handler, "CREATE TEMP TABLE numeric_test (id BIGSERIAL, numcol NUMERIC)")
+
+          val id = executePreparedStatement(handler, "INSERT INTO numeric_test DEFAULT VALUES RETURNING id").rows.get(0)("id")
+          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](123.123, id))
+          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](1234, id))
+          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](123.123, id))
+
+          id === 1
+      }
+
+    }
+
+    "support first update of num column with integer (fails currently)" in {
+
+      withHandler {
+        handler =>
+          executeDdl(handler, "CREATE TEMP TABLE numeric_test (id BIGSERIAL, numcol NUMERIC)")
+
+          val id = executePreparedStatement(handler, "INSERT INTO numeric_test DEFAULT VALUES RETURNING id").rows.get(0)("id")
+          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](1234, id))
+          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](123.123, id))
+
+          id === 1
+      }
+
+    }
+
+    "support using first update with queries instead of prepared statements" in {
+
+      withHandler {
+        handler =>
+          executeDdl(handler, "CREATE TEMP TABLE numeric_test (id BIGSERIAL, numcol NUMERIC)")
+
+          val id = executeQuery(handler, "INSERT INTO numeric_test DEFAULT VALUES RETURNING id").rows.get(0)("id")
+          executeQuery(handler, s"UPDATE numeric_test SET numcol = 1234 WHERE id = $id")
+          executeQuery(handler, s"UPDATE numeric_test SET numcol = 123.123 WHERE id = $id")
+
+          id === 1
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
When using `NUMERIC` columns, updating them with an integer value at first and updating it with a floating number later, an exception is thrown. It looks like this happens with `PreparedStatements` only and I couldn't reproduce it on the database directly using IntelliJ database console.

See the Spec in the PR for a reproducer of this issue.
