### PR TITLE
Add SSL support.

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/Configuration.scala
@@ -37,6 +37,7 @@ object Configuration {
  * @param port database port, defaults to 5432
  * @param password password, defaults to no password
  * @param database database name, defaults to no database
+ * @param ssl ssl configuration
  * @param charset charset for the connection, defaults to UTF-8, make sure you know what you are doing if you
  *                change this
  * @param maximumMessageSize the maximum size a message from the server could possibly have, this limits possible
@@ -55,6 +56,7 @@ case class Configuration(username: String,
                          port: Int = 5432,
                          password: Option[String] = None,
                          database: Option[String] = None,
+                         ssl: SSLConfiguration = SSLConfiguration(),
                          charset: Charset = Configuration.DefaultCharset,
                          maximumMessageSize: Int = 16777216,
                          allocator: ByteBufAllocator = PooledByteBufAllocator.DEFAULT,

--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/SSLConfiguration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/SSLConfiguration.scala
@@ -1,0 +1,27 @@
+package com.github.mauricio.async.db
+
+/**
+ *
+ * Contains the SSL configuration necessary to connect to a database.
+ *
+ * @param enabled enable ssl, defaults to false
+ * @param optional fallback to plaintext connection if server doesn't support ssl, defaults to false
+ * @param rootFile path to PEM encoded trusted root certificates, None to use internal JDK cacerts, defaults to None
+ * @param verifyRoot verify root certificate validity, defaults to true
+ * @param verifyHostname verify peer certificate hostname, defaults to true
+ *
+ */
+case class SSLConfiguration(enabled: Boolean = false,
+                            optional: Boolean = false,
+                            rootFile: Option[String] = None,
+                            verifyRoot: Boolean = true,
+                            verifyHostname: Boolean = true)
+
+object SSLConfiguration {
+  def apply(properties: Map[String, String]): SSLConfiguration = SSLConfiguration(
+      enabled = properties.get("ssl").map(_.toBoolean).getOrElse(false),
+      optional = properties.get("sslOptional").map(_.toBoolean).getOrElse(false),
+      rootFile = properties.get("sslRootFile"),
+      verifyRoot = properties.get("sslVerifyRoot").map(_.toBoolean).getOrElse(true),
+      verifyHostname = properties.get("sslVerifyHostname").map(_.toBoolean).getOrElse(true))
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/MessageEncoder.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/MessageEncoder.scala
@@ -44,12 +44,13 @@ class MessageEncoder(charset: Charset, encoderRegistry: ColumnEncoderRegistry) e
   override def encode(ctx: ChannelHandlerContext, msg: AnyRef, out: java.util.List[Object]) = {
 
     val buffer = msg match {
+      case SSLRequestMessage => SSLMessageEncoder.encode()
+      case message: StartupMessage => startupEncoder.encode(message)
       case message: ClientMessage => {
         val encoder = (message.kind: @switch) match {
           case ServerMessage.Close => CloseMessageEncoder
           case ServerMessage.Execute => this.executeEncoder
           case ServerMessage.Parse => this.openEncoder
-          case ServerMessage.Startup => this.startupEncoder
           case ServerMessage.Query => this.queryEncoder
           case ServerMessage.PasswordMessage => this.credentialEncoder
           case _ => throw new EncoderNotAvailableException(message)

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/codec/PostgreSQLConnectionHandler.scala
@@ -38,6 +38,13 @@ import com.github.mauricio.async.db.postgresql.messages.backend.RowDescriptionMe
 import com.github.mauricio.async.db.postgresql.messages.backend.ParameterStatusMessage
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.CodecException
+import io.netty.handler.ssl.{SslContextBuilder, SslHandler}
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory
+import io.netty.util.concurrent.FutureListener
+import java.io.File
+import javax.net.ssl.{SSLParameters, TrustManagerFactory}
+import java.security.KeyStore
+import java.io.FileInputStream
 
 object PostgreSQLConnectionHandler {
   final val log = Log.get[PostgreSQLConnectionHandler]
@@ -79,7 +86,7 @@ class PostgreSQLConnectionHandler
 
       override def initChannel(ch: channel.Channel): Unit = {
         ch.pipeline.addLast(
-          new MessageDecoder(configuration.charset, configuration.maximumMessageSize),
+          new MessageDecoder(configuration.ssl.enabled, configuration.charset, configuration.maximumMessageSize),
           new MessageEncoder(configuration.charset, encoderRegistry),
           PostgreSQLConnectionHandler.this)
       }
@@ -120,12 +127,60 @@ class PostgreSQLConnectionHandler
   }
 
   override def channelActive(ctx: ChannelHandlerContext): Unit = {
-    ctx.writeAndFlush(new StartupMessage(this.properties))
+    if (configuration.ssl.enabled)
+      ctx.writeAndFlush(SSLRequestMessage)
+    else
+      ctx.writeAndFlush(new StartupMessage(this.properties))
   }
 
   override def channelRead0(ctx: ChannelHandlerContext, msg: Object): Unit = {
 
     msg match {
+
+      case SSLResponseMessage(supported) =>
+        if (supported) {
+          val ctxBuilder = SslContextBuilder.forClient()
+          if (configuration.ssl.verifyRoot) {
+            configuration.ssl.rootFile.fold {
+              val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+              val ks = KeyStore.getInstance(KeyStore.getDefaultType())
+              val cacerts = new FileInputStream(System.getProperty("java.home") + "/lib/security/cacerts")
+              try {
+                ks.load(cacerts, "changeit".toCharArray)
+              } finally {
+                cacerts.close()
+              }
+              tmf.init(ks)
+              ctxBuilder.trustManager(tmf)
+            } { path =>
+              ctxBuilder.trustManager(new File(path))
+            }
+          } else {
+            ctxBuilder.trustManager(InsecureTrustManagerFactory.INSTANCE)
+          }
+          val sslContext = ctxBuilder.build()
+          val sslEngine = sslContext.newEngine(ctx.alloc(), configuration.host, configuration.port)
+          if (configuration.ssl.verifyHostname) {
+            val sslParams = sslEngine.getSSLParameters()
+            sslParams.setEndpointIdentificationAlgorithm("HTTPS")
+            sslEngine.setSSLParameters(sslParams)
+          }
+          val handler = new SslHandler(sslEngine)
+          ctx.pipeline().addFirst(handler)
+          handler.handshakeFuture.addListener(new FutureListener[channel.Channel]() {
+            def operationComplete(future: io.netty.util.concurrent.Future[channel.Channel]) {
+              if (future.isSuccess()) {
+                ctx.writeAndFlush(new StartupMessage(properties))
+              } else {
+                connectionDelegate.onError(future.cause())
+              }
+            }
+          })
+        } else if (configuration.ssl.optional) {
+          ctx.writeAndFlush(new StartupMessage(properties))
+        } else {
+          connectionDelegate.onError(new IllegalArgumentException("SSL is not supported on server"))
+        }
 
       case m: ServerMessage => {
 

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/SSLMessageEncoder.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/SSLMessageEncoder.scala
@@ -1,0 +1,16 @@
+package com.github.mauricio.async.db.postgresql.encoders
+
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+
+object SSLMessageEncoder {
+
+  def encode(): ByteBuf = {
+    val buffer = Unpooled.buffer()
+    buffer.writeInt(8)
+    buffer.writeShort(1234)
+    buffer.writeShort(5679)
+    buffer
+  }
+
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/StartupMessageEncoder.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/encoders/StartupMessageEncoder.scala
@@ -21,13 +21,11 @@ import com.github.mauricio.async.db.util.ByteBufferUtils
 import java.nio.charset.Charset
 import io.netty.buffer.{Unpooled, ByteBuf}
 
-class StartupMessageEncoder(charset: Charset) extends Encoder {
+class StartupMessageEncoder(charset: Charset) {
 
   //private val log = Log.getByName("StartupMessageEncoder")
 
-  override def encode(message: ClientMessage): ByteBuf = {
-
-    val startup = message.asInstanceOf[StartupMessage]
+  def encode(startup: StartupMessage): ByteBuf = {
 
     val buffer = Unpooled.buffer()
     buffer.writeInt(0)

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/backend/SSLResponseMessage.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/backend/SSLResponseMessage.scala
@@ -1,0 +1,3 @@
+package com.github.mauricio.async.db.postgresql.messages.backend
+
+case class SSLResponseMessage(supported: Boolean)

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/backend/ServerMessage.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/backend/ServerMessage.scala
@@ -43,7 +43,6 @@ object ServerMessage {
   final val Query = 'Q'
   final val RowDescription = 'T'
   final val ReadyForQuery = 'Z'
-  final val Startup = '0'
   final val Sync = 'S'
 }
 

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/InitialClientMessage.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/InitialClientMessage.scala
@@ -1,0 +1,3 @@
+package com.github.mauricio.async.db.postgresql.messages.frontend
+
+trait InitialClientMessage

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/SSLRequestMessage.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/SSLRequestMessage.scala
@@ -1,0 +1,5 @@
+package com.github.mauricio.async.db.postgresql.messages.frontend
+
+import com.github.mauricio.async.db.postgresql.messages.backend.ServerMessage
+
+object SSLRequestMessage extends InitialClientMessage

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/StartupMessage.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/messages/frontend/StartupMessage.scala
@@ -16,6 +16,4 @@
 
 package com.github.mauricio.async.db.postgresql.messages.frontend
 
-import com.github.mauricio.async.db.postgresql.messages.backend.ServerMessage
-
-class StartupMessage(val parameters: List[(String, Any)]) extends ClientMessage(ServerMessage.Startup)
+class StartupMessage(val parameters: List[(String, Any)]) extends InitialClientMessage

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/ParserURL.scala
@@ -16,28 +16,37 @@ object ParserURL {
   val PGPORT = "port"
   val PGDBNAME = "database"
   val PGHOST = "host"
-  val PGUSERNAME = "username"
+  val PGUSERNAME = "user"
   val PGPASSWORD = "password"
 
   val DEFAULT_PORT = "5432"
 
-  private val pgurl1 = """(jdbc:postgresql):(?://([^/:]*|\[.+\])(?::(\d+))?)?(?:/([^/?]*))?(?:\?user=(.*)&password=(.*))?""".r
-  private val pgurl2 = """(postgres|postgresql)://(.*):(.*)@(.*):(\d+)/(.*)""".r
+  private val pgurl1 = """(jdbc:postgresql):(?://([^/:]*|\[.+\])(?::(\d+))?)?(?:/([^/?]*))?(?:\?(.*))?""".r // (?:\?user=(.*)(?:&password=(.*))(?:&ssl=(true|false)))?
+  private val pgurl2 = """(postgres|postgresql)://(.*):(.*)@(.*):(\d+)/(.*)(?:\?(.*))?""".r
 
   def parse(connectionURL: String): Map[String, String] = {
     val properties: Map[String, String] = Map()
 
+    def parseOptions(optionsStr: String): Map[String, String] =
+      optionsStr.split("&").map { o =>
+        o.span(_ != '=') match {
+          case (name, value) => name -> value.drop(1)
+        }
+      }.toMap
+
     connectionURL match {
-      case pgurl1(protocol, server, port, dbname, username, password) => {
+      case pgurl1(protocol, server, port, dbname, params) => {
         var result = properties
         if (server != null) result += (PGHOST -> unwrapIpv6address(server))
         if (dbname != null && dbname.nonEmpty) result += (PGDBNAME -> dbname)
-        if(port != null) result += (PGPORT -> port)
-        if(username != null) result = (result + (PGUSERNAME -> username) + (PGPASSWORD -> password))
+        if (port != null) result += (PGPORT -> port)
+        if (params != null) result ++= parseOptions(params)
         result
       }
-      case pgurl2(protocol, username, password, server, port, dbname) => {
-        properties + (PGHOST -> unwrapIpv6address(server)) + (PGPORT -> port) + (PGDBNAME -> dbname) + (PGUSERNAME -> username) + (PGPASSWORD -> password)
+      case pgurl2(protocol, username, password, server, port, dbname, params) => {
+        var result = properties + (PGHOST -> unwrapIpv6address(server)) + (PGPORT -> port) + (PGDBNAME -> dbname) + (PGUSERNAME  -> username) + (PGPASSWORD  -> password)
+        if (params != null) result ++= parseOptions(params)
+        result
       }
       case _ => {
         logger.warn(s"Connection url '$connectionURL' could not be parsed.")

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/URLParser.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/util/URLParser.scala
@@ -16,13 +16,10 @@
 
 package com.github.mauricio.async.db.postgresql.util
 
-import com.github.mauricio.async.db.Configuration
+import com.github.mauricio.async.db.{Configuration, SSLConfiguration}
 import java.nio.charset.Charset
 
 object URLParser {
-
-  private val Username = "username"
-  private val Password = "password"
 
   import Configuration.Default
 
@@ -35,11 +32,12 @@ object URLParser {
     val port = properties.get(ParserURL.PGPORT).getOrElse(ParserURL.DEFAULT_PORT).toInt
 
     new Configuration(
-      username = properties.get(Username).getOrElse(Default.username),
-      password = properties.get(Password),
+      username = properties.get(ParserURL.PGUSERNAME).getOrElse(Default.username),
+      password = properties.get(ParserURL.PGPASSWORD),
       database = properties.get(ParserURL.PGDBNAME),
       host = properties.getOrElse(ParserURL.PGHOST, Default.host),
       port = port,
+      ssl = SSLConfiguration(properties),
       charset = charset
     )
 

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/MessageDecoderSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/MessageDecoderSpec.scala
@@ -27,7 +27,7 @@ import java.util
 
 class MessageDecoderSpec extends Specification {
 
-  val decoder = new MessageDecoder(CharsetUtil.UTF_8)
+  val decoder = new MessageDecoder(false, CharsetUtil.UTF_8)
 
   "message decoder" should {
 


### PR DESCRIPTION
SSL is disabled by default to avoid POLA violations.
It is possible to enable it by adding `ssl=true` in the url parameters.
Other parameters control the SSL behavior:
- it's possible to use JDK root CAs (default) or a set of custom CAs
  with `sslRootFile=<path.pem>` param or accept any certificates with
  `sslVerifyRoot=false` param
- peer certificate hostname check can be disabled with
  `sslVerifyHostname=false` param
- the connection can fallback to plaintext communication if the
  server doesn't support SSL with `sslOptional=true` param, similar
  to psql cli

Client certificate authentication is not implemented, due to lack of
time and interest, but it should be easy to add.