### PR TITLE
Time unit as a part of javadoc

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PoolConfiguration.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/pool/PoolConfiguration.scala
@@ -25,7 +25,7 @@ object PoolConfiguration {
  * Defines specific pieces of a pool's behavior.
  *
  * @param maxObjects how many objects this pool will hold
- * @param maxIdle how long are objects going to be kept as idle (not in use by clients of the pool)
+ * @param maxIdle number of milliseconds for which the objects are going to be kept as idle (not in use by clients of the pool)
  * @param maxQueueSize when there are no more objects, the pool can queue up requests to serve later then there
  *                     are objects available, this is the maximum number of enqueued requests
  * @param validationInterval pools will use this value as the timer period to validate idle objects.


### PR DESCRIPTION
I wanted to know the time unit being used for idle and I had to look
into the iplementation to be sure. I think it might be useful to have
this in the javadoc directly.