### PR TITLE
Support java.net.InetAddress and user-defined types

### DIFF
--- a/db-async-common/src/main/scala/com/github/mauricio/async/db/column/InetAddressEncoderDecoder.scala
+++ b/db-async-common/src/main/scala/com/github/mauricio/async/db/column/InetAddressEncoderDecoder.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 Maurício Linhares
+ *
+ * Maurício Linhares licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.github.mauricio.async.db.column
+
+import java.net.InetAddress
+import sun.net.util.IPAddressUtil.{textToNumericFormatV4,textToNumericFormatV6}
+
+object InetAddressEncoderDecoder extends ColumnEncoderDecoder {
+
+  override def decode(value: String): Any = {
+    if (value contains ':') {
+      InetAddress.getByAddress(textToNumericFormatV6(value))
+    } else {
+      InetAddress.getByAddress(textToNumericFormatV4(value))
+    }
+  }
+
+  override def encode(value: Any): String = {
+    value.asInstanceOf[InetAddress].getHostAddress
+  }
+
+}

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
@@ -67,6 +67,8 @@ object ColumnTypes {
   final val UUIDArray = 2951
   final val XMLArray = 143
 
+  final val Inet = 869
+  final val InetArray = 1041
 }
 
 /*

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnDecoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnDecoderRegistry.scala
@@ -46,6 +46,7 @@ class PostgreSQLColumnDecoderRegistry( charset : Charset = CharsetUtil.UTF_8 ) e
   private final val timeWithTimestampArrayDecoder = new ArrayDecoder(TimeWithTimezoneEncoderDecoder)
   private final val intervalArrayDecoder = new ArrayDecoder(PostgreSQLIntervalEncoderDecoder)
   private final val uuidArrayDecoder = new ArrayDecoder(UUIDEncoderDecoder)
+  private final val inetAddressArrayDecoder = new ArrayDecoder(InetAddressEncoderDecoder)
 
   override def decode(kind: ColumnData, value: ByteBuf, charset: Charset): Any = {
     decoderFor(kind.dataType).decode(kind, value, charset)
@@ -113,6 +114,9 @@ class PostgreSQLColumnDecoderRegistry( charset : Charset = CharsetUtil.UTF_8 ) e
       case UUIDArray => this.uuidArrayDecoder
       case XMLArray => this.stringArrayDecoder
       case ByteA => ByteArrayEncoderDecoder
+
+      case Inet => InetAddressEncoderDecoder
+      case InetArray => this.inetAddressArrayDecoder
 
       case _ => StringEncoderDecoder
     }

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/ArrayTypesSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/ArrayTypesSpec.scala
@@ -16,31 +16,45 @@
 
 package com.github.mauricio.async.db.postgresql
 
-import com.github.mauricio.async.db.column.TimestampWithTimezoneEncoderDecoder
+import com.github.mauricio.async.db.column.{TimestampWithTimezoneEncoderDecoder, InetAddressEncoderDecoder}
 import org.specs2.mutable.Specification
+import java.net.InetAddress
 
 class ArrayTypesSpec extends Specification with DatabaseTestHelper {
-
-  val simpleCreate = """create temp table type_test_table (
-            bigserial_column bigserial not null,
-            smallint_column integer[] not null,
-            text_column text[] not null,
-            timestamp_column timestamp with time zone[] not null,
-            constraint bigserial_column_pkey primary key (bigserial_column)
-          )"""
+  // `uniq` allows sbt to run the tests concurrently as there is no CREATE TEMP TYPE
+  def simpleCreate(uniq: String) = s"""DROP TYPE IF EXISTS dir_$uniq;
+                                       CREATE TYPE direction_$uniq AS ENUM ('in','out');
+                                       DROP TYPE IF EXISTS endpoint_$uniq;
+                                       CREATE TYPE endpoint_$uniq AS (ip inet, port integer);
+                                       create temp table type_test_table_$uniq (
+                                         bigserial_column bigserial not null,
+                                         smallint_column integer[] not null,
+                                         text_column text[] not null,
+                                         inet_column inet[] not null,
+                                         direction_column direction_$uniq[] not null,
+                                         endpoint_column endpoint_$uniq[] not null,
+                                         timestamp_column timestamp with time zone[] not null,
+                                         constraint bigserial_column_pkey primary key (bigserial_column)
+                                       )"""
+  def simpleDrop(uniq: String)   = s"""drop table if exists type_test_table_$uniq;
+                                       drop type  if exists endpoint_$uniq;
+                                       drop type  if exists direction_$uniq"""
 
   val insert =
-    """insert into type_test_table
-      (smallint_column, text_column, timestamp_column)
+    """insert into type_test_table_cptat
+      (smallint_column, text_column, inet_column, direction_column, endpoint_column, timestamp_column)
       values (
       '{1,2,3,4}',
       '{"some,\"comma,separated,text","another line of text","fake\,backslash","real\\,backslash\\",NULL}',
+      '{"127.0.0.1","2002:15::1"}',
+      '{"in","out"}',
+      '{"(\"127.0.0.1\",80)","(\"2002:15::1\",443)"}',
       '{"2013-04-06 01:15:10.528-03","2013-04-06 01:15:08.528-03"}'
       )"""
 
-  val insertPreparedStatement = """insert into type_test_table
-            (smallint_column, text_column, timestamp_column)
-            values (?,?,?)"""
+  val insertPreparedStatement = """insert into type_test_table_csaups
+                                                 (smallint_column, text_column, inet_column, direction_column, endpoint_column, timestamp_column)
+                                                 values (?,?,?,?,?,?)"""
 
   "connection" should {
 
@@ -48,41 +62,62 @@ class ArrayTypesSpec extends Specification with DatabaseTestHelper {
 
       withHandler {
         handler =>
-          executeDdl(handler, simpleCreate)
-          executeDdl(handler, insert, 1)
-          val result = executeQuery(handler, "select * from type_test_table").rows.get
-          result(0)("smallint_column") === List(1,2,3,4)
-          result(0)("text_column") === List("some,\"comma,separated,text", "another line of text", "fake,backslash", "real\\,backslash\\", null )
-          result(0)("timestamp_column") === List(
-            TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:10.528-03"),
-            TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:08.528-03")
-          )
+          try {
+            executeDdl(handler, simpleCreate("cptat"))
+            executeDdl(handler, insert, 1)
+            val result = executeQuery(handler, "select * from type_test_table_cptat").rows.get
+            result(0)("smallint_column") === List(1,2,3,4)
+            result(0)("text_column") === List("some,\"comma,separated,text", "another line of text", "fake,backslash", "real\\,backslash\\", null )
+            result(0)("timestamp_column") === List(
+              TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:10.528-03"),
+              TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:08.528-03")
+            )
+          } finally {
+            executeDdl(handler, simpleDrop("cptat"))
+          }
       }
 
     }
 
     "correctly send arrays using prepared statements" in {
+      case class Endpoint(ip: InetAddress, port: Int)
 
       val timestamps = List(
         TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:10.528-03"),
         TimestampWithTimezoneEncoderDecoder.decode("2013-04-06 01:15:08.528-03")
+      )
+      val inets = List(
+        InetAddressEncoderDecoder.decode("127.0.0.1"),
+        InetAddressEncoderDecoder.decode("2002:15::1")
+      )
+      val directions = List("in", "out")
+      val endpoints = List(
+        Endpoint(InetAddress.getByName("127.0.0.1"),  80),  // case class
+                (InetAddress.getByName("2002:15::1"), 443)  // tuple
       )
       val numbers = List(1,2,3,4)
       val texts = List("some,\"comma,separated,text", "another line of text", "fake,backslash", "real\\,backslash\\", null )
 
       withHandler {
         handler =>
-          executeDdl(handler, simpleCreate)
-          executePreparedStatement(
-            handler,
-            this.insertPreparedStatement,
-            Array( numbers, texts, timestamps ) )
+          try {
+            executeDdl(handler, simpleCreate("csaups"))
+            executePreparedStatement(
+              handler,
+              this.insertPreparedStatement,
+              Array( numbers, texts, inets, directions, endpoints, timestamps ) )
 
-          val result = executeQuery(handler, "select * from type_test_table").rows.get
+            val result = executeQuery(handler, "select * from type_test_table_csaups").rows.get
 
-          result(0)("smallint_column") === numbers
-          result(0)("text_column") === texts
-          result(0)("timestamp_column") === timestamps
+            result(0)("smallint_column") === numbers
+            result(0)("text_column") === texts
+            result(0)("inet_column") === inets
+            result(0)("direction_column") === "{in,out}"                                 // user type decoding not supported
+            result(0)("endpoint_column") === """{"(127.0.0.1,80)","(2002:15::1,443)"}""" // user type decoding not supported
+            result(0)("timestamp_column") === timestamps
+          } finally {
+            executeDdl(handler, simpleDrop("csaups"))
+          }
       }
 
     }


### PR DESCRIPTION
Added support for PostgreSQL [INET](https://www.postgresql.org/docs/9.6/static/datatype-net-types.html) data type and [user-defined types](https://www.postgresql.org/docs/9.6/static/sql-createtype.html) which are similar to Scala tuples and case classes.

INET is decoded and encoded by the driver much like the Timestamp type.
User types can be encoded (used in INSERTS, this was what I needed) but not decoded. 
I think decoding them would require using Scala macros which implies bumping required Scala version from 2.10 to 2.11 and and some refactoring (macros can be used for the basic types as well instead of reflection). So for a small patch I decided not to go into decoding user types into case classes.