### PR TITLE
fix wrong type matching for postgresql in query statements

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/PostgreSQLConnection.scala
@@ -119,7 +119,9 @@ class PostgreSQLConnection
     val promise = Promise[QueryResult]()
     this.setQueryPromise(promise)
 
-    val holder = this.parsedStatements.getOrElseUpdate(query,
+    val statementKey = query + "|" + values.map(value => encoderRegistry.kindOf(value)).mkString(",")
+
+    val holder = this.parsedStatements.getOrElseUpdate(statementKey,
       new PreparedStatementHolder( query, preparedStatementsCounter.incrementAndGet ))
 
     if (holder.paramsCount != values.length) {

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/ColumnTypes.scala
@@ -20,6 +20,8 @@ object ColumnTypes {
   final val Untyped = 0
   final val Bigserial = 20
   final val BigserialArray = 1016
+  final val Bigint = 20
+  final val BigintArray = 1016
   final val Char = 18
   final val CharArray = 1002
   final val Smallint = 21

--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
@@ -31,14 +31,14 @@ object PostgreSQLColumnEncoderRegistry {
 class PostgreSQLColumnEncoderRegistry extends ColumnEncoderRegistry {
 
   private val classesSequence_ : List[(Class[_], (ColumnEncoder, Int))] = List(
-    classOf[Int] -> (IntegerEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Integer] -> (IntegerEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Int] -> (IntegerEncoderDecoder -> ColumnTypes.Integer),
+    classOf[java.lang.Integer] -> (IntegerEncoderDecoder -> ColumnTypes.Integer),
 
-    classOf[java.lang.Short] -> (ShortEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[Short] -> (ShortEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[java.lang.Short] -> (ShortEncoderDecoder -> ColumnTypes.Integer),
+    classOf[Short] -> (ShortEncoderDecoder -> ColumnTypes.Integer),
 
-    classOf[Long] -> (LongEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Long] -> (LongEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Long] -> (LongEncoderDecoder -> ColumnTypes.Bigint),
+    classOf[java.lang.Long] -> (LongEncoderDecoder -> ColumnTypes.Bigint),
 
     classOf[String] -> (StringEncoderDecoder -> ColumnTypes.Varchar),
     classOf[java.lang.String] -> (StringEncoderDecoder -> ColumnTypes.Varchar),


### PR DESCRIPTION
postgresql performance degradation on sql like`select ... where id::bigint in ({1,2,3}::numeric[])`