### PR TITLE
Fixed performance regression caused by treating all numbers as numerics

### DIFF
--- a/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
+++ b/postgresql-async/src/main/scala/com/github/mauricio/async/db/postgresql/column/PostgreSQLColumnEncoderRegistry.scala
@@ -31,23 +31,23 @@ object PostgreSQLColumnEncoderRegistry {
 class PostgreSQLColumnEncoderRegistry extends ColumnEncoderRegistry {
 
   private val classesSequence_ : List[(Class[_], (ColumnEncoder, Int))] = List(
-    classOf[Int] -> (IntegerEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Integer] -> (IntegerEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Int] -> (IntegerEncoderDecoder -> ColumnTypes.Integer),
+    classOf[java.lang.Integer] -> (IntegerEncoderDecoder -> ColumnTypes.Integer),
 
-    classOf[java.lang.Short] -> (ShortEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[Short] -> (ShortEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[java.lang.Short] -> (ShortEncoderDecoder -> ColumnTypes.Smallint),
+    classOf[Short] -> (ShortEncoderDecoder -> ColumnTypes.Smallint),
 
-    classOf[Long] -> (LongEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Long] -> (LongEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Long] -> (LongEncoderDecoder -> ColumnTypes.Bigserial),
+    classOf[java.lang.Long] -> (LongEncoderDecoder -> ColumnTypes.Bigserial),
 
     classOf[String] -> (StringEncoderDecoder -> ColumnTypes.Varchar),
     classOf[java.lang.String] -> (StringEncoderDecoder -> ColumnTypes.Varchar),
 
-    classOf[Float] -> (FloatEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Float] -> (FloatEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Float] -> (FloatEncoderDecoder -> ColumnTypes.Real),
+    classOf[java.lang.Float] -> (FloatEncoderDecoder -> ColumnTypes.Real),
 
-    classOf[Double] -> (DoubleEncoderDecoder -> ColumnTypes.Numeric),
-    classOf[java.lang.Double] -> (DoubleEncoderDecoder -> ColumnTypes.Numeric),
+    classOf[Double] -> (DoubleEncoderDecoder -> ColumnTypes.Double),
+    classOf[java.lang.Double] -> (DoubleEncoderDecoder -> ColumnTypes.Double),
 
     classOf[BigDecimal] -> (BigDecimalEncoderDecoder -> ColumnTypes.Numeric),
     classOf[java.math.BigDecimal] -> (BigDecimalEncoderDecoder -> ColumnTypes.Numeric),

--- a/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/NumericSpec.scala
+++ b/postgresql-async/src/test/scala/com/github/mauricio/async/db/postgresql/NumericSpec.scala
@@ -30,7 +30,6 @@ class NumericSpec extends Specification with DatabaseTestHelper {
 
           val id = executePreparedStatement(handler, "INSERT INTO numeric_test DEFAULT VALUES RETURNING id").rows.get(0)("id")
           executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](1234, id))
-          executePreparedStatement(handler, "UPDATE numeric_test SET numcol = ? WHERE id = ?", Array[Any](123.123, id))
 
           id === 1
       }


### PR DESCRIPTION
Change 90e4194adb2d02b229fcccdc754513e486518bb7 switched the types used for numbers in PreparedStatements to always be ColumnType.Numeric.

This causes an order of magnitude performance degradation, as shown by the test in this PR, also discussed in #179 

The effect of reverting this change means that you cannot create a prepared statement using say integer types and then start passing doubles to it.  Which would be a pretty dubious practice to do anyway! 