### PR TITLE
fix mysql memory leak

### DIFF
--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLConnectionHandler.scala
@@ -51,7 +51,7 @@ class MySQLConnectionHandler(
   extends SimpleChannelInboundHandler[Object] {
 
   private implicit val internalPool = executionContext
-  private final val log = Log.getByName(s"[connection-handler]${connectionId}")
+  private final val log = Log.getByName("[connection-handler]")
   private final val bootstrap = new Bootstrap().group(this.group)
   private final val connectionPromise = Promise[MySQLConnectionHandler]
   private final val decoder = new MySQLFrameDecoder(configuration.charset, connectionId)

--- a/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoder.scala
+++ b/mysql-async/src/main/scala/com/github/mauricio/async/db/mysql/codec/MySQLFrameDecoder.scala
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class MySQLFrameDecoder(charset: Charset, connectionId: String) extends ByteToMessageDecoder {
 
-  private final val log = Log.getByName(s"[frame-decoder]${connectionId}")
+  private final val log = Log.getByName("[frame-decoder]")
   private final val messagesCount = new AtomicInteger()
   private final val handshakeDecoder = new HandshakeV10Decoder(charset)
   private final val errorDecoder = new ErrorDecoder(charset)


### PR DESCRIPTION
We've been investigating a leak in some of our applications for a while.
It turns out that over several hours, many mysql connections
created/destroyed/recycled and quite a few logger instances are left behind

Related: https://github.com/mauricio/postgresql-async/pull/86